### PR TITLE
Fix Issue 20 in Android: fullscreen property seem not work

### DIFF
--- a/src/it/mobimentum/phonegapspinnerplugin/ProgressActivity.java
+++ b/src/it/mobimentum/phonegapspinnerplugin/ProgressActivity.java
@@ -27,9 +27,6 @@ public class ProgressActivity extends Activity {
 		
 		// Remove title bar
 	    this.requestWindowFeature(Window.FEATURE_NO_TITLE);
-
-	    // Remove notification bar
-	    this.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
 		
 		// Intent
 		Intent intent = getIntent();


### PR DESCRIPTION
hi @mauriziopinotti 
I am using PGB 3.6 with plugin 1.2.10
when I set the "fullscreen" property to true or false in Android it will show a fullscreen display (the status bar will disappear Temporarily)，it look like all the same.

This pull request fix this.