### PR TITLE
Fix for Cordova 6

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -25,10 +25,7 @@
  
 	<config-file target="AndroidManifest.xml" parent="/manifest/application">
 		<activity android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale" android:name="it.mobimentum.phonegapspinnerplugin.ProgressActivity"
-		          android:theme="@android:style/Theme.Translucent.NoTitleBar" android:launchMode="singleInstance">
-		          <intent-filter>
-		          </intent-filter>
-	      	</activity>
+		          android:theme="@android:style/Theme.Translucent.NoTitleBar" android:launchMode="singleInstance" />
 	</config-file>
  
         <source-file src="src/it/mobimentum/phonegapspinnerplugin/SpinnerPlugin.java" target-dir="src/it/mobimentum/phonegapspinnerplugin/" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -23,13 +23,13 @@
             </feature>
         </config-file>
  
-				<config-file target="AndroidManifest.xml" parent="/manifest/application">
-		      <activity android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale" android:name="it.mobimentum.phonegapspinnerplugin.ProgressActivity"
+	<config-file target="AndroidManifest.xml" parent="/manifest/application">
+		<activity android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale" android:name="it.mobimentum.phonegapspinnerplugin.ProgressActivity"
 		          android:theme="@android:style/Theme.Translucent.NoTitleBar" android:launchMode="singleInstance">
 		          <intent-filter>
 		          </intent-filter>
-		      </activity>
-				</config-file>
+	      	</activity>
+	</config-file>
  
         <source-file src="src/it/mobimentum/phonegapspinnerplugin/SpinnerPlugin.java" target-dir="src/it/mobimentum/phonegapspinnerplugin/" />
         <source-file src="src/it/mobimentum/phonegapspinnerplugin/ProgressActivity.java" target-dir="src/it/mobimentum/phonegapspinnerplugin/" />


### PR DESCRIPTION
This is to address the (closed) issue #27 . When building the project, the intent-filter tag within the AndroidManifest.xml needs to have a corresponding action and category. Since they are not needed, they may just be omitted. I have had no issues with the plugin otherwise. 
